### PR TITLE
Change path to point to /tmp/

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,22 @@
 const net = require('net')
 const fs = require('fs')
+const path = require('path');
 
 var counter = 0
 class UnixStream {
   constructor (stream, onSocket) {
-    const path = './' + (++counter) + '.sock'
-    this.url = 'unix:' + path
+    const socketPath = path.resolve('/tmp/', (++counter), '.sock');
+    this.url = 'unix:' + socketPath
 
     try {
-      fs.statSync(path)
-      fs.unlinkSync(path)
+      fs.statSync(socketPath)
+      fs.unlinkSync(socketPath)
     } catch (err) {}
     const server = net.createServer(onSocket)
     stream.on('finish', () => {
       server.close()
     })
-    server.listen(path)
+    server.listen(socketPath)
   }
 }
 


### PR DESCRIPTION
Hey,
first of all - thanks, this is a great package.
But making the .sock files point to your source code directory is cluttering your workspace quickly. I changed the default path to point to /tmp/ dir.
This would make development 10000x times smoother.
Let me know if there are any hidden drawbacks to this.